### PR TITLE
added a parameter for ghsearch.repos()

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ ghsearch.issues('pksunkara/hub', 'open', 'git', callback); //array of issues
 #### Search repositories
 
 ```js
-ghsearch.repos('git', 'javascript', callback); //array of repositories
+ghsearch.repos('git', 'javascript', 1, callback); //array of repositories
 ```
 
 #### Search users


### PR DESCRIPTION
according to the source code, ghsearch.repos() should provide start_page parameter
