### PR TITLE
Making the request object available as part of the client class.

### DIFF
--- a/lib/octonode/client.js
+++ b/lib/octonode/client.js
@@ -4,7 +4,7 @@
     __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
     __slice = [].slice;
 
-  request = require('request');
+  this.request = request = require('request');
 
   Me = require('./me');
 

--- a/src/octonode/client.coffee
+++ b/src/octonode/client.coffee
@@ -5,7 +5,7 @@
 #
 
 # Requiring modules
-request = require 'request'
+@request = request = require 'request'
 
 Me   = require './me'
 User = require './user'


### PR DESCRIPTION
This makes it much easier to stub out the request object for testing purposes and to set parameters like proxies

There's an argument for the rest of the modules too, but I didn't want to delve that deep.
