### PR TITLE
Membership check for an individual user is returning the incorrect results

### DIFF
--- a/lib/octonode/org.js
+++ b/lib/octonode/org.js
@@ -96,7 +96,7 @@
         if (err) {
           return cb(err);
         }
-        return cb(null, s === 204 || s === 302);
+        return cb(null, s === 204);
       });
     };
 

--- a/src/octonode/org.coffee
+++ b/src/octonode/org.coffee
@@ -62,7 +62,7 @@ class Org
   member: (user, cb) ->
     @client.getNoFollow "/orgs/#{@name}/members/#{user}", (err, s, b)  ->
       return cb(err) if err
-      cb null, s is 204 or s is 302
+      cb null, s is 204
 
 # Export module
 module.exports = Org


### PR DESCRIPTION
In a previous pull request I added a check for 302 for the membership check. This is in fact incorrect. I would very much like to write a test case for this too, but the case I need to implement needs to act as authenticated user and I am obviously not keen on publishing any of my own access tokens. 

I guess we can keep the access token in an environment variable or somewhere on your file system outside of the source control. How would you like this done?
