### PR TITLE
Add repo releases

### DIFF
--- a/src/octonode/repo.coffee
+++ b/src/octonode/repo.coffee
@@ -57,6 +57,13 @@ class Repo
       return cb(err) if err
       if s isnt 200 then cb(new Error("Repo tags error")) else cb null, b, h
 
+  # Get the releases for a repository
+  # '/repos/pksunkara/hub/releases' GET
+  releases: (cb) ->
+    @client.get "/repos/#{@name}/releases", (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error("Repo releases error")) else cb null, b, h
+
   # Get the languages for a repository
   # '/repos/pksunkara/hub/languages' GET
   languages: (cb) ->


### PR DESCRIPTION
- Add releases to Repo class with url /repos/:owner/:repo/releases

Was looking to use this for sethvincent/generator-ghost#3 but couldn't find the releases method.  Url came from the [Github API documentation on releases](http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository).
