### PR TITLE
Change `util-extend` package for the `deep-extend`. 

### DIFF
--- a/lib/octonode/client.js
+++ b/lib/octonode/client.js
@@ -26,7 +26,7 @@
 
   Issue = require('./issue');
 
-  extend = require('util-extend');
+  extend = require('deep-extend');
 
   Search = require('./search');
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "request": "2.27.x",
     "randomstring": "1.x.x",
-    "util-extend": "1.x.x"
+    "deep-extend": "0.x.x"
   },
   "devDependencies": {
     "nock": "0.7.x",

--- a/src/octonode/client.coffee
+++ b/src/octonode/client.coffee
@@ -16,7 +16,7 @@ Gist  = require './gist'
 Team  = require './team'
 Pr    = require './pr'
 Issue = require './issue'
-extend = require 'util-extend'
+extend = require 'deep-extend'
 
 Search = require './search'
 


### PR DESCRIPTION
This makes sure no request parameters get wiped during building request objects.

Fixes #89. I wrongly assumed that the `util-extend` was a deep copy. It isn't. This one is.
