### PR TITLE
Fixing bug where search query is appended to URL even if it doesn't exist!

### DIFF
--- a/lib/octonode/client.js
+++ b/lib/octonode/client.js
@@ -141,7 +141,9 @@
         pathname: path,
         query: query
       });
-      _url += "" + separator + "q=" + q;
+      if (q) {
+        _url += "" + separator + "q=" + q;
+      }
       return _url;
     };
 

--- a/src/octonode/client.coffee
+++ b/src/octonode/client.coffee
@@ -101,7 +101,9 @@ class Client
       pathname: path
       query: query
 
-    _url += "#{separator}q=#{q}"
+    if q
+      _url += "#{separator}q=#{q}"
+
     return _url
 
   errorHandle: (res, body, callback) ->


### PR DESCRIPTION
I think this was accidentaly introduced in #88, I only found out because I ended up with a URL ending in:

`access_token=HSidfmksdj8j2dsfundefinedq=undefined` which obviously screwed my authentication.
