### PR TITLE
Handle HTTP 204 on a repo having no contributors

### DIFF
--- a/lib/octonode/repo.js
+++ b/lib/octonode/repo.js
@@ -121,12 +121,10 @@
         }
         if (s === 204) {
           return cb(null, [], h);
+        } else if (s !== 200) {
+          return cb(new Error("Repo contributors error"));
         } else {
-          if (s !== 200) {
-            return cb(new Error("Repo contributors error"));
-          } else {
-            return cb(null, b, h);
-          }
+          return cb(null, b, h);
         }
       });
     };

--- a/src/octonode/repo.coffee
+++ b/src/octonode/repo.coffee
@@ -78,11 +78,7 @@ class Repo
       return cb(err) if err
       if s is 204
         cb null, [], h
-      else
-        if s isnt 200
-          cb(new Error("Repo contributors error"))
-        else
-          cb null, b, h
+      else if s isnt 200 then cb(new Error("Repo contributors error")) else cb null, b, h
 
   # Get the teams for a repository
   # '/repos/pksunkara/hub/teams' GET


### PR DESCRIPTION
When a repository has no contributors (it can happen!) the `/repo/x/y/contributors` call returns a 204, which Octonode translates into an error, whereas it should be a empty result.
