### PR TITLE
Enable pagination in me.starred method

### DIFF
--- a/lib/octonode/me.js
+++ b/lib/octonode/me.js
@@ -164,22 +164,19 @@
       })(this));
     };
 
-    Me.prototype.starred = function(cbOrRepo, cb) {
-      if ((cb != null) && typeof cbOrRepo !== 'function') {
-        return this.checkStarred(cbOrRepo, cb);
-      } else {
-        cb = cbOrRepo;
-        return this.client.get('/user/starred', function(err, s, b, h) {
-          if (err) {
-            return cb(err);
-          }
-          if (s !== 200) {
-            return cb(new Error('User starred error'));
-          } else {
-            return cb(null, b, h);
-          }
-        });
-      }
+    Me.prototype.starred = function() {
+      var cb, params, _i, _ref;
+      params = 2 <= arguments.length ? __slice.call(arguments, 0, _i = arguments.length - 1) : (_i = 0, []), cb = arguments[_i++];
+      return (_ref = this.client).get.apply(_ref, ['/user/starred'].concat(__slice.call(params), [function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error('User starred error'));
+        } else {
+          return cb(null, b, h);
+        }
+      }]));
     };
 
     Me.prototype.checkStarred = function(repo, cb) {

--- a/src/octonode/me.coffee
+++ b/src/octonode/me.coffee
@@ -101,12 +101,8 @@ class Me
   # Get the starred repos for the user
   # '/user/starred' GET
   # TODO: page, user
-  starred: (cbOrRepo, cb) ->
-    if cb? and typeof cbOrRepo isnt 'function'
-      @checkStarred cbOrRepo, cb
-    else
-      cb = cbOrRepo
-      @client.get '/user/starred', (err, s, b, h)  ->
+  starred: (params..., cb) ->
+      @client.get '/user/starred', params..., (err, s, b, h)  ->
         return cb(err) if err
         if s isnt 200 then cb(new Error('User starred error')) else cb null, b, h
 


### PR DESCRIPTION
API would change to

``` javascript
var github = require('./lib/octonode');

var client = github.client({
  username: 'xxxxxxxx',
  password: 'xxxxxxxxx'
});

client.me().starred(2, 30, function(err,data) {
  console.log(data);
});

client.me().checkStarred('slate/slate', function(err,data) {
  console.log(data);
});
```

Using the starred method to both fetch starred repositories and check if a repo has been starred adds complexity to the API. I think splitting into two method definitions is better: easier to test, can evolve independently
