### PR TITLE
Additional checks for null tokens

### DIFF
--- a/lib/octonode/client.js
+++ b/lib/octonode/client.js
@@ -126,11 +126,13 @@
           query.per_page = per_page;
         }
       }
-      if (typeof this.token === 'string') {
-        query.access_token = this.token;
-      } else if (typeof this.token === 'object' && this.token.id) {
-        query.client_id = this.token.id;
-        query.client_secret = this.token.secret;
+      if (this.token) {
+        if (typeof this.token === 'string') {
+          query.access_token = this.token;
+        } else if (typeof this.token === 'object' && this.token.id) {
+          query.client_id = this.token.id;
+          query.client_secret = this.token.secret;
+        }
       }
       if (query.q) {
         q = query.q;

--- a/src/octonode/client.coffee
+++ b/src/octonode/client.coffee
@@ -84,11 +84,12 @@ class Client
       query = {}
       query.page     = pageOrQuery if pageOrQuery?
       query.per_page = per_page if per_page?
-    if typeof @token == 'string'
-      query.access_token = @token
-    else if typeof @token == 'object' and @token.id
-      query.client_id = @token.id
-      query.client_secret = @token.secret
+    if @token
+      if typeof @token == 'string'
+        query.access_token = @token
+      else if typeof @token == 'object' and @token.id
+        query.client_id = @token.id
+        query.client_secret = @token.secret
 
     # https://github.com/pksunkara/octonode/issues/87
     if query.q


### PR DESCRIPTION
We had a bug in our code where we were passing in a token with a value of `null`. This was causing Octonode to throw an unhandled exception. This tiny pull request just does an additional check to ensure that the token exists. (as `typeof null === 'object` in Javascripts topsey-turvy type system)
