### PR TITLE
Return all Event Types if no Event Type filter supplied

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,8 +406,16 @@ ghuser.following(callback); //array of github users
 
 This query supports [pagination](#pagination).
 
+Optionally, supply an array of Event Types to filter by.
+
 ```js
-ghuser.events(['PushEvent'], callback); //array of events
+ghuser.events(['PushEvent'], callback); //array of PushEvent events
+```
+
+Or leave it out to get all Event Types.
+
+```js
+ghuser.events(callback); //array of events
 ```
 
 #### Get user public organizations (GET /users/pksunkara/orgs)

--- a/lib/octonode/user.js
+++ b/lib/octonode/user.js
@@ -66,7 +66,7 @@
       if (!cb && typeof events === 'function') {
         cb = events;
         events = null;
-      } else if (!Array.isArray(events)) {
+      } else if ((events != null) && !Array.isArray(events)) {
         events = [events];
       }
       return (_ref = this.client).get.apply(_ref, ["/users/" + this.login + "/events"].concat(__slice.call(params), [function(err, s, b, h) {
@@ -76,9 +76,11 @@
         if (s !== 200) {
           return cb(new Error('User events error'));
         }
-        b = b.filter(function(event) {
-          return events.indexOf(event.type) !== -1;
-        });
+        if (events != null) {
+          b = b.filter(function(event) {
+            return events.indexOf(event.type) !== -1;
+          });
+        }
         return cb(null, b, h);
       }]));
     };

--- a/src/octonode/user.coffee
+++ b/src/octonode/user.coffee
@@ -48,15 +48,16 @@ class User
     if !cb and typeof events == 'function'
       cb = events
       events = null
-    else if !Array.isArray events
+    else if events? and !Array.isArray events
       events = [events]
 
     @client.get "/users/#{@login}/events", params..., (err, s, b, h)  ->
       return cb(err) if err
       return cb(new Error('User events error')) if s isnt 200
 
-      b = b.filter (event) ->
-        return events.indexOf(event.type) != -1
+      if events?
+        b = b.filter (event) ->
+          return events.indexOf(event.type) != -1
 
       cb null, b, h
 


### PR DESCRIPTION
Instead of an empty array.
