### PR TITLE
Updating request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   ],
   "dependencies": {
-    "request": "2.34.x",
+    "request": "2.44.x",
     "randomstring": "1.x.x",
     "deep-extend": "0.x.x"
   },


### PR DESCRIPTION
See https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking and https://nodesecurity.io/advisories/qs_dos_memory_exhaustion.
### Steps to reproduce

``` sh
$ git clone https://github.com/pksunkara/octonode.git .

$ npm install

$ npm shrinkwrap --dev
wrote npm-shrinkwrap.json

$ # sudo npm i nsp -g
$ nsp audit-shrinkwrap
Name  Installed  Patched  Vulnerable Dependency
qs      0.6.6     >= 1.x  octonode > request

$ npm outdated --depth 0
Package        Current  Wanted  Latest  Location
coffee-script    1.7.1   1.7.1   1.8.0  coffee-script
nock             0.7.3   0.7.3  0.48.0  nock
request         2.34.0  2.34.0  2.44.0  request

# .travis.yml not found

$ # sudo npm i pjv -g
$ pjv -wr
{ valid: true }
```
