### PR TITLE
Remove `start_page` parameter from user search.

### DIFF
--- a/src/octonode/search.coffee
+++ b/src/octonode/search.coffee
@@ -24,7 +24,7 @@ class Search
       if s isnt 200 then cb(new Error('Search repos error')) else cb null, b, h
 
   # Search users
-  users: (params, start_page, cb) ->
+  users: (params, cb) ->
     @client.get "/search/users", params, (err, s, b, h) ->
       return cb(err) if err
       if s isnt 200 then cb(new Error('Search users error')) else cb null, b, h


### PR DESCRIPTION
It seems to be an artifact of 5247e53d4b51d53ba9f4d5848d902b39dbfb5291 and does not exist anymore in the documentation.
