### PR TITLE
Add option "port" for client

### DIFF
--- a/src/octonode/client.coffee
+++ b/src/octonode/client.coffee
@@ -108,6 +108,7 @@ class Client
       protocol: @options and @options.protocol or "https:"
       auth: if @token and @token.username and @token.password then "#{@token.username}:#{@token.password}" else ''
       hostname: @options and @options.hostname or "api.github.com"
+      port: @options and @options.port
       pathname: path
       query: query
 


### PR DESCRIPTION
We are using octonode to connect to an API which is a clone of the GitHub API but to test locally we need to connect to `locahost:8000` which is not possible with the current init of the client
