### PR TITLE
Add support for the GitHub Memberships check API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 *.swp
 docs
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -742,6 +742,12 @@ ghorg.members(callback); //array of github users
 ghorg.member('pksunkara', callback); //boolean
 ```
 
+#### Check a member's membership status (GET /orgs/flatiron/memberships/pksunkara)
+
+```js
+ghorg.memberships('pksunkara', callback); //membership status object indicating state, role, etc.
+```
+
 #### Create an organization team (POST /orgs/flatiron/teams)
 
 ```js

--- a/lib/octonode/org.js
+++ b/lib/octonode/org.js
@@ -99,6 +99,23 @@
       }]));
     };
 
+    Org.prototype.membership = function(user, cb) {
+      return this.client.getOptions("/orgs/" + this.name + "/memberships/" + user, {
+        headers: {
+          Accept: 'application/vnd.github.moondragon+json'
+        }
+      }, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error('Org memberships error'));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Org.prototype.member = function(user, cb) {
       return this.client.getNoFollow("/orgs/" + this.name + "/members/" + user, function(err, s, b, h) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octonode",
-  "version": "0.6.15",
+  "version": "0.6.14",
   "author": "Pavan Kumar Sunkara <pavan.sss1991@gmail.com> (http://pksunkara.github.com)",
   "description": "nodejs wrapper for github v3 api",
   "main": "./lib/octonode",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octonode",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "author": "Pavan Kumar Sunkara <pavan.sss1991@gmail.com> (http://pksunkara.github.com)",
   "description": "nodejs wrapper for github v3 api",
   "main": "./lib/octonode",

--- a/src/octonode/org.coffee
+++ b/src/octonode/org.coffee
@@ -64,6 +64,13 @@ class Org
       return cb(err) if err
       if s isnt 200 then cb(new Error('Org members error')) else cb null, b, h
 
+  # Check membership for a user in the org.
+  # '/orgs/flatiron/memberships/pksunkara' GET
+  membership: (user, cb) ->
+    @client.getOptions "/orgs/#{@name}/memberships/#{user}", { headers: { Accept: 'application/vnd.github.moondragon+json'} },(err, s, b, h)  ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error('Org memberships error')) else cb null, b, h
+
   # Check an organization's member.
   # '/orgs/flatiron/members/pksunkara' GET
   member: (user, cb) ->


### PR DESCRIPTION
With the updates to the organization APIs on GitHub, there's a need for some new endpoints.

The https://developer.github.com/v3/orgs/members/#check-membership API is currently in opt-in preview, and requires a specific Accept header for that call. This PR adds the API and uses the existing getOptions client call to do so.

General info on the changes: https://developer.github.com/changes/2015-01-07-prepare-for-organization-permissions-changes/

Understand if you would rather wait until the API ships on the GitHub side without the requirement for the special header. I didn't find much test coverage on the org side so have not added any tests, sry.

Thanks.