### PR TITLE
Adding the API to check an org member's public membership choice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,12 @@ ghorg.members(callback); //array of github users
 ghorg.member('pksunkara', callback); //boolean
 ```
 
+#### Check a member's public membership in an org (GET /orgs/flatiron/public_members/pksunkara)
+
+```js
+ghorg.publicMember('pksunkara', callback); //boolean
+```
+
 #### Create an organization team (POST /orgs/flatiron/teams)
 
 ```js

--- a/lib/octonode/org.js
+++ b/lib/octonode/org.js
@@ -108,6 +108,15 @@
       });
     };
 
+    Org.prototype.publicMember = function(user, cb) {
+      return this.client.getNoFollow("/orgs/" + this.name + "/public_members/" + user, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        return cb(null, s === 204, h);
+      });
+    };
+
     Org.prototype.createTeam = function(options, cb) {
       return this.client.post("/orgs/" + this.name + "/teams", options, function(err, s, b, h) {
         if (err) {

--- a/src/octonode/org.coffee
+++ b/src/octonode/org.coffee
@@ -71,6 +71,13 @@ class Org
       return cb(err) if err
       cb null, s is 204, h
 
+  # Check an organization's public member.
+  # '/orgs/flatiron/public_members/pksunkara' GET
+  publicMember: (user, cb) ->
+    @client.getNoFollow "/orgs/#{@name}/public_members/#{user}", (err, s, b, h)  ->
+      return cb(err) if err
+      cb null, s is 204, h
+
   # Create an organisation team
   # '/orgs/flatiron/teams' POST
   createTeam: (options, cb) ->


### PR DESCRIPTION
This adds support for the "check public membership" API exposed to organizations, which I'm now using in an app.

Documented here: https://developer.github.com/v3/orgs/members/#check-public-membership