### PR TITLE
Implementing additional GitHub APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,17 @@ ghme.issues({
 }, callback); //array of issues
 ```
 
+#### List user teams (GET /user/teams)
+
+This query supports [pagination](#pagination).
+
+```js
+ghme.teams({
+  page: 1,
+  per_page: 50
+}, callback); //array of team memberships
+```
+
 ## Github users api
 
 No token required for the following
@@ -763,6 +774,18 @@ ghorg.member('pksunkara', callback); //boolean
 ghorg.publicMember('pksunkara', callback); //boolean
 ```
 
+#### Publicize a user’s membership (PUT /orgs/flatiron/public_members/pksunkara)
+
+```js
+ghorg.publicizeMembership('pksunkara', callback);
+```
+
+#### Conceal a user’s membership (DELETE /orgs/flatiron/public_members/pksunkara)
+
+```js
+ghorg.concealMembership('pksunkara', callback);
+```
+
 #### Check a member's membership status (GET /orgs/flatiron/memberships/pksunkara)
 
 ```js
@@ -803,6 +826,28 @@ This query supports [pagination](#pagination).
 
 ```js
 ghissue.comments(callback); //array of comments
+```
+
+#### Create a comment (POST /repos/pksunkara/hub/issues/37/comments)
+
+```js
+ghissue.createComment({
+  body: 'Me too.'
+}, callback);
+```
+
+#### Edit a comment (PATCH /repos/pksunkara/hub/issues/comments/3)
+
+```js
+ghissue.updateComment(3, {
+  body: 'The updated body of the comment.'
+}, callback);
+```
+
+#### Delete a comment (DELETE /repos/pksunkara/hub/issues/comments/3)
+
+```js
+ghissue.deleteComment(3, callback);
 ```
 
 ## Github milestones api
@@ -1046,6 +1091,24 @@ ghteam.addUser("pksunkara", callback); //boolean
 
 ```js
 ghteam.removeUser("pksunkara", callback); //boolean
+```
+
+#### Get team membership (GET /teams/37/memberships/pksunkara)
+
+```js
+ghteam.membership("pksunkara", callback); //boolean
+```
+
+#### Add team membership (PUT /teams/37/memberships/pksunkara)
+
+```js
+ghteam.addMembership("pksunkara", callback); //boolean
+```
+
+#### Remove team membership (DELETE /team/37/memberships/pksunkara)
+
+```js
+ghteam.removeMembership("pksunkara", callback); //boolean
 ```
 
 #### List all repos of a team (GET /team/37/repos)

--- a/lib/octonode/issue.js
+++ b/lib/octonode/issue.js
@@ -24,7 +24,7 @@
     };
 
     Issue.prototype.update = function(obj, cb) {
-      return this.client.post("/repos/" + this.repo + "/issues/" + this.number, obj, function(err, s, b, h) {
+      return this.client.patch("/repos/" + this.repo + "/issues/" + this.number, obj, function(err, s, b, h) {
         if (err) {
           return cb(err);
         }
@@ -49,6 +49,47 @@
           return cb(null, b, h);
         }
       }]));
+    };
+
+    Issue.prototype.createComment = function(comment, cb) {
+      return this.client.post("/repos/" + this.repo + "/issues/" + this.number + "/comments", comment, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 201) {
+          return cb(new Error('Issue createComment error'));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
+    Issue.prototype.updateComment = function(id, comment, cb) {
+      return this.client.patch("/repos/" + this.repo + "/issues/comments/" + id, comment, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error('Issue updateComment error'));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
+    Issue.prototype.deleteComment = function(id) {
+      return this.client.del("/repos/" + this.repo + "/issues/comments/" + id, {}, (function(_this) {
+        return function(err, s, b, h) {
+          if (err) {
+            return cb(err);
+          }
+          if (s !== 204) {
+            return cb(new Error("Issue deleteComment error"));
+          } else {
+            return cb(null, b, h);
+          }
+        };
+      })(this));
     };
 
     return Issue;

--- a/lib/octonode/me.js
+++ b/lib/octonode/me.js
@@ -443,6 +443,21 @@
       }]));
     };
 
+    Me.prototype.teams = function() {
+      var cb, i, params, ref;
+      params = 2 <= arguments.length ? slice.call(arguments, 0, i = arguments.length - 1) : (i = 0, []), cb = arguments[i++];
+      return (ref = this.client).get.apply(ref, ["/user/teams"].concat(slice.call(params), [function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error("User teams error"));
+        } else {
+          return cb(null, b, h);
+        }
+      }]));
+    };
+
     return Me;
 
   })();

--- a/lib/octonode/org.js
+++ b/lib/octonode/org.js
@@ -136,6 +136,45 @@
       });
     };
 
+    Org.prototype.publicizeMembership = function(user, cb) {
+      return this.client.put("/orgs/" + this.name + "/public_members/" + user, null, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 204) {
+          return cb(new Error("Org publicizeMembership error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
+    Org.prototype.concealMembership = function(user, cb) {
+      return this.client.del("/orgs/" + this.name + "/public_members/" + user, null, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 204) {
+          return cb(new Error("Org concealMembership error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
+    Org.prototype.removeMember = function(user, cb) {
+      return this.client.del("/orgs/" + this.name + "/members/" + user, null, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 204) {
+          return cb(new Error("Org removeMember error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Org.prototype.createTeam = function(options, cb) {
       return this.client.post("/orgs/" + this.name + "/teams", options, function(err, s, b, h) {
         if (err) {

--- a/lib/octonode/team.js
+++ b/lib/octonode/team.js
@@ -22,6 +22,19 @@
       });
     };
 
+    Team.prototype.update = function(info, cb) {
+      return this.client.patch("/teams/" + this.id, info, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error('Team update error'));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Team.prototype.members = function() {
       var cb, i, params, ref;
       params = 2 <= arguments.length ? slice.call(arguments, 0, i = arguments.length - 1) : (i = 0, []), cb = arguments[i++];
@@ -51,7 +64,11 @@
         if (err) {
           return cb(err);
         }
-        return cb(null, s === 204, h);
+        if (s !== 204) {
+          return cb(new Error("Team addUser error"));
+        } else {
+          return cb(null, b, h);
+        }
       });
     };
 
@@ -60,7 +77,46 @@
         if (err) {
           return cb(err);
         }
+        if (s !== 204) {
+          return cb(new Error("Team removeUser error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
+    Team.prototype.membership = function(user, cb) {
+      return this.client.get("/teams/" + this.id + "/memberships/" + user, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
         return cb(null, s === 204, h);
+      });
+    };
+
+    Team.prototype.addMembership = function(user, cb) {
+      return this.client.put("/teams/" + this.id + "/memberships/" + user, null, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error("Team membership error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
+    Team.prototype.removeMembership = function(user, cb) {
+      return this.client.del("/teams/" + this.id + "/memberships/" + user, null, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 204) {
+          return cb(new Error("Team removeMembership error"));
+        } else {
+          return cb(null, b, h);
+        }
       });
     };
 

--- a/src/octonode/issue.coffee
+++ b/src/octonode/issue.coffee
@@ -19,7 +19,7 @@ class Issue
   # Edit an issue for a repository
   # '/repos/pksunkara/hub/issues/37' PATCH
   update: (obj, cb) ->
-    @client.post "/repos/#{@repo}/issues/#{@number}", obj, (err, s, b, h) ->
+    @client.patch "/repos/#{@repo}/issues/#{@number}", obj, (err, s, b, h) ->
       return cb(err) if err
       if s isnt 200 then cb(new Error("Issue update error")) else cb null, b, h
 
@@ -31,6 +31,27 @@ class Issue
     @client.get "/repos/" + @repo + "/issues/" + @number + "/comments", params..., (err, s, b, h)  ->
       return cb(err) if err
       if s isnt 200 then cb(new Error('Issue Comments error')) else cb null, b, h
+
+  # Create a comment
+  # '/repos/pksunkara/hub/issues/37/comments' POST
+  createComment: (comment, cb) ->
+    @client.post "/repos/#{@repo}/issues/#{@number}/comments", comment, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 201 then cb(new Error('Issue createComment error')) else cb null, b, h
+
+  # Edit a comment
+  # '/repos/pksunkara/hub/issues/comments/3' PATCH
+  updateComment: (id, comment, cb) ->
+    @client.patch "/repos/#{@repo}/issues/comments/#{id}", comment, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error('Issue updateComment error')) else cb null, b, h
+
+  # Delete a comment
+  # '/repos/pksunkara/hub/issues/comments/3' DELETE
+  deleteComment: (id) ->
+    @client.del "/repos/#{@repo}/issues/comments/#{id}", {}, (err, s, b, h) =>
+      return cb(err) if err
+      if s isnt 204 then cb(new Error("Issue deleteComment error")) else cb null, b, h
 
 # Export module
 module.exports = Issue

--- a/src/octonode/me.coffee
+++ b/src/octonode/me.coffee
@@ -265,5 +265,14 @@ class Me
       return cb(err) if err
       if s isnt 200 then cb(new Error("User issues error")) else cb null, b, h
 
+  # List all team memberships across the authenticated user's organizations
+  # '/user/teams' GET
+  # - page or query object, optional - params[0]
+  # - per_page, optional             - params[1]
+  teams: (params..., cb) ->
+    @client.get "/user/teams", params..., (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error("User teams error")) else cb null, b, h
+
 # Export module
 module.exports = Me

--- a/src/octonode/org.coffee
+++ b/src/octonode/org.coffee
@@ -87,6 +87,27 @@ class Org
       return cb(err) if err
       cb null, s is 204, h
 
+  # Publicize the authenticated user's membership in an organization.
+  # '/orgs/flatiron/public_members/pksunkara' PUT
+  publicizeMembership: (user, cb) ->
+    @client.put "/orgs/#{@name}/public_members/#{user}", null, (err, s, b, h) ->
+      return cb(err)  if err
+      if s isnt 204 then cb new Error("Org publicizeMembership error") else cb null, b, h
+
+  # Conceal public membership of the authenticated user in the organization.
+  # '/orgs/flatiron/public_members/pksunkara' DELETE
+  concealMembership: (user, cb) ->
+    @client.del "/orgs/#{@name}/public_members/#{user}", null, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 204 then cb(new Error("Org concealMembership error")) else cb null, b, h
+
+  # Remove a user from an organization and all of its teams
+  # '/orgs/flatiron/members/pksunkara' DELETE
+  removeMember: (user, cb) ->
+    @client.del "/orgs/#{@name}/members/#{user}", null, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 204 then cb(new Error("Org removeMember error")) else cb null, b, h
+
   # Create an organisation team
   # '/orgs/flatiron/teams' POST
   createTeam: (options, cb) ->

--- a/src/octonode/team.coffee
+++ b/src/octonode/team.coffee
@@ -18,6 +18,13 @@ class Team
       return cb(err) if err
       if s isnt 200 then cb(new Error('Team info error')) else cb null, b, h
 
+  # Edit a team
+  # '/teams/37' PATCH
+  update: (info, cb) ->
+    @client.patch "/teams/#{@id}", info, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error('Team update error')) else cb null, b, h
+
   # Get a teams's members
   # '/teams/37/members' GET
   # - page or query object, optional - params[0]
@@ -39,14 +46,35 @@ class Team
   addUser: (user, cb) ->
     @client.put "/teams/#{@id}/members/#{user}", null,  (err, s, b, h) ->
       return cb(err) if err
-      cb null, s is 204, h
+      if s isnt 204 then cb(new Error("Team addUser error")) else cb null, b, h
 
   # Remove a user from a team (must have admin permissions to do so)
   # '/teams/37/members/pksunkara' DELETE
   removeUser: (user, cb) ->
     @client.del "/teams/#{@id}/members/#{user}", null, (err, s, b, h) ->
       return cb(err) if err
+      if s isnt 204 then cb(new Error("Team removeUser error")) else cb null, b, h
+
+  # Check a team's membership
+  # '/teams/37/memberships/pksunkara' GET
+  membership: (user, cb) ->
+    @client.get "/teams/#{@id}/memberships/#{user}", (err, s, b, h)  ->
+      return cb(err) if err
       cb null, s is 204, h
+
+  # Add a user to a team's membership
+  # '/teams/37/memberships/pksunkara' PUT
+  addMembership: (user, cb) ->
+    @client.put "/teams/#{@id}/memberships/#{user}", null,  (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error("Team membership error")) else cb null, b, h
+
+  # Remove a user from a team's membership
+  # '/teams/37/memberships/pksunkara' DELETE
+  removeMembership: (user, cb) ->
+    @client.del "/teams/#{@id}/memberships/#{user}", null, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 204 then cb(new Error("Team removeMembership error")) else cb null, b, h
 
   # List repos of a team
   # '/teams/37/repos/' GET


### PR DESCRIPTION
Hi,
This PR contains a number of additional GitHub V3 API calls that I implemented back in February and March. Given the units of work are independent and represent different API calls, I have no squashed many commits together. Happy to change that if you prefer.

APIs implemented include:

- Issue APIs:     
  - Creating a comment
  - Updating a comment
  - Deleting a comment
- "Me" API:
  - Listing the authenticated user's team memberships
- Organization APIs:
  - Publicizing a user's org membership   
  - Concealing a user's org membership
  - Removing a member from an organization
- Team APIs:
  - Updating a team 
  - Checking for the membership of a user in a team
  - Adding team membership           
  - Removing team membership

Thanks,
Jeff