### PR TITLE
Adding `repo.update` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,14 @@ ghuser.orgs(callback); //array of organizations
 ghrepo.info(callback); //json
 ```
 
+#### Edit a repository (PATCH /repos/pksunkara/hub)
+
+```js
+ghrepo.update({
+  private: false
+}, callback); // repo
+```
+
 #### Get the collaborators for a repository (GET /repos/pksunkara/hub/collaborators)
 
 ```js

--- a/lib/octonode/repo.js
+++ b/lib/octonode/repo.js
@@ -22,6 +22,19 @@
       });
     };
 
+    Repo.prototype.update = function(info, cb) {
+      return this.client.patch("/repos/" + this.name, info, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error("Repo update error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Repo.prototype.collaborators = function(cbOrUser, cb) {
       if ((cb != null) && typeof cbOrUser !== 'function') {
         return this.hasCollaborator(cbOrUser, cb);

--- a/src/octonode/repo.coffee
+++ b/src/octonode/repo.coffee
@@ -18,6 +18,13 @@ class Repo
       return cb(err) if err
       if s isnt 200 then cb(new Error("Repo info error")) else cb null, b, h
 
+  # Edit a repository
+  # '/repos/pksunkara/hub' PATCH
+  update: (info, cb) ->
+    @client.patch "/repos/#{@name}", info, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error("Repo update error")) else cb null, b, h
+
   # Get the collaborators for a repository
   # '/repos/pksunkara/hub/collaborators
   collaborators: (cbOrUser, cb) ->


### PR DESCRIPTION
This change uses PATCH to edit a repo. This can be used to change the description of a repo, change it from private to public, etc.