### PR TITLE
Fixing the expected response code from ghorg.addTeamRepo

### DIFF
--- a/lib/octonode/org.js
+++ b/lib/octonode/org.js
@@ -162,6 +162,19 @@
       });
     };
 
+    Org.prototype.addMember = function(user, options, cb) {
+      return this.client.put("/orgs/" + this.name + "/memberships/" + user, options, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 204) {
+          return cb(new Error("Org addMember error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Org.prototype.removeMember = function(user, cb) {
       return this.client.del("/orgs/" + this.name + "/members/" + user, null, function(err, s, b, h) {
         if (err) {
@@ -193,7 +206,7 @@
         if (err) {
           return cb(err);
         }
-        if (s !== 201) {
+        if (s !== 204) {
           return cb(new Error('Org addTeamRepo error'));
         } else {
           return cb(null, b, h);

--- a/src/octonode/org.coffee
+++ b/src/octonode/org.coffee
@@ -122,12 +122,12 @@ class Org
       return cb(err) if err
       if s isnt 201 then cb(new Error('Org createTeam error')) else cb null, b, h
 
-  # Create an organisation team repository
+  # Add an organisation team repository
   # '/teams/37/repos/flatiron/hub' PUT
   addTeamRepo: (team, repo, cb) ->
     @client.put "/teams/#{team}/repos/#{@name}/#{repo}", null, (err, s, b, h) ->
       return cb(err)  if err
-      if s isnt 201 then cb(new Error('Org addTeamRepo error')) else cb null, b, h
+      if s isnt 204 then cb(new Error('Org addTeamRepo error')) else cb null, b, h
 
 # Export module
 module.exports = Org


### PR DESCRIPTION
This fixes the response code per the GitHub API documentation and test use for the `ghorg.addTeamRepo` function.

Also improves the comment to better describe as GitHub does what the function call does.

Note, `cake lib` was generating a function from a previous commit of another use for a function `addMember`, so I have included this here for now. LMK if I should not include the generated bit.