### PR TITLE
Team.removeRepo was not present in generated library code.

### DIFF
--- a/lib/octonode/team.js
+++ b/lib/octonode/team.js
@@ -135,6 +135,19 @@
       }]));
     };
 
+    Team.prototype.removeRepo = function(repo, cb) {
+      return this.client.del("/teams/" + this.id + "/repos/" + repo, {}, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 204) {
+          return cb(new Error("Team removeRepo error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Team.prototype.destroy = function(cb) {
       return this.client.del("/teams/" + this.id, {}, function(err, s, b, h) {
         if (err) {


### PR DESCRIPTION
Looks like a method is not in the current checked-in generated JS.