### PR TITLE
Updating APIs for the newer GitHub organization management system

### DIFF
--- a/lib/octonode/team.js
+++ b/lib/octonode/team.js
@@ -90,12 +90,32 @@
         if (err) {
           return cb(err);
         }
-        return cb(null, s === 204, h);
+        return cb(null, s === 204 || s === 200, h);
       });
     };
 
-    Team.prototype.addMembership = function(user, cb) {
-      return this.client.put("/teams/" + this.id + "/memberships/" + user, null, function(err, s, b, h) {
+    Team.prototype.getMembership = function(user, cb) {
+      return this.client.get("/teams/" + this.id + "/memberships/" + user, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error("Team getMembership error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
+    Team.prototype.addMembership = function(user, cbOrOptions, cb) {
+      var param;
+      if ((cb == null) && cbOrOptions) {
+        cb = cbOrOptions;
+        param = {};
+      } else if (typeof cbOrOptions === 'object') {
+        param = cbOrOptions;
+      }
+      return this.client.put("/teams/" + this.id + "/memberships/" + user, param, function(err, s, b, h) {
         if (err) {
           return cb(err);
         }
@@ -133,6 +153,19 @@
           return cb(null, b, h);
         }
       }]));
+    };
+
+    Team.prototype.removeRepo = function(repo, cb) {
+      return this.client.del("/teams/" + this.id + "/repos/" + repo, {}, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 204) {
+          return cb(new Error("Team removeRepo error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
     };
 
     Team.prototype.destroy = function(cb) {

--- a/src/octonode/team.coffee
+++ b/src/octonode/team.coffee
@@ -60,12 +60,24 @@ class Team
   membership: (user, cb) ->
     @client.get "/teams/#{@id}/memberships/#{user}", (err, s, b, h)  ->
       return cb(err) if err
-      cb null, s is 204, h
+      cb null, s is 204 or s is 200, h
+
+  # Get a team's membership object for the user
+  # '/teams/37/memberships/pksunkara' GET
+  getMembership: (user, cb) ->
+    @client.get "/teams/#{@id}/memberships/#{user}", (err, s, b, h)  ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error("Team getMembership error")) else cb null, b, h
 
   # Add a user to a team's membership
   # '/teams/37/memberships/pksunkara' PUT
-  addMembership: (user, cb) ->
-    @client.put "/teams/#{@id}/memberships/#{user}", null,  (err, s, b, h) ->
+  addMembership: (user, cbOrOptions, cb) ->
+    if !cb? and cbOrOptions
+      cb = cbOrOptions
+      param = {}
+    else if typeof cbOrOptions is 'object'
+      param = cbOrOptions
+    @client.put "/teams/#{@id}/memberships/#{user}", param,  (err, s, b, h) ->
       return cb(err) if err
       if s isnt 200 then cb(new Error("Team membership error")) else cb null, b, h
 


### PR DESCRIPTION
Hi,
This is an initial PR but likely we will want to iterate. I wanted to get your initial feedback related to the new GitHub organization management system that began broadly rolling out yesterday - [details here](https://github.com/blog/2064-new-organization-permissions-now-available).

A few things:

- The status code returned by the API for the membership check is different for the new system and old... for in the interim I've considered accepting HTTP 200 _and_ 204. (200 new, 204 old)
- There is now a `state` property and object associated with a membership check. As a result, instead of breaking the old experience (a true/false return value), I've added yet another method to return that. Not sure what your thoughts are on that.

Will also comment inline...

Thanks for your thoughts,
Jeff