### PR TITLE
Team Get Members API: supporting the new organization system

### DIFF
--- a/lib/octonode/team.js
+++ b/lib/octonode/team.js
@@ -38,7 +38,11 @@
     Team.prototype.members = function() {
       var cb, i, params, ref;
       params = 2 <= arguments.length ? slice.call(arguments, 0, i = arguments.length - 1) : (i = 0, []), cb = arguments[i++];
-      return (ref = this.client).get.apply(ref, ["/teams/" + this.id + "/members"].concat(slice.call(params), [function(err, s, b, h) {
+      return (ref = this.client).getOptions.apply(ref, ["/teams/" + this.id + "/members", {
+        headers: {
+          Accept: 'application/vnd.github.ironman-preview+json'
+        }
+      }].concat(slice.call(params), [function(err, s, b, h) {
         if (err) {
           return cb(err);
         }

--- a/src/octonode/team.coffee
+++ b/src/octonode/team.coffee
@@ -29,8 +29,9 @@ class Team
   # '/teams/37/members' GET
   # - page or query object, optional - params[0]
   # - per_page, optional             - params[1]
+  # - role, optional                 - params[2]
   members: (params..., cb) ->
-    @client.get "/teams/#{@id}/members", params..., (err, s, b, h)  ->
+    @client.getOptions "/teams/#{@id}/members", { headers: { Accept: 'application/vnd.github.ironman-preview+json'} }, params..., (err, s, b, h)  ->
       return cb(err) if err
       if s isnt 200 then cb(new Error('Team members error')) else cb null, b, h
 


### PR DESCRIPTION
Team Get Members API: supporting the new organization system by providing a custom Accept header allowing the 'role' parameter to be passed in for filtering the team members.

The body of the response is identical, however supplying `role` as a filtering parameter for the method only actually filters when sending the preview API Accept header. In time this will not be required.

API documentation: https://developer.github.com/v3/orgs/teams/#list-team-members