### PR TITLE
Updating repo collaborators to support paging objects.

### DIFF
--- a/lib/octonode/repo.js
+++ b/lib/octonode/repo.js
@@ -35,12 +35,22 @@
       });
     };
 
-    Repo.prototype.collaborators = function(cbOrUser, cb) {
-      if ((cb != null) && typeof cbOrUser !== 'function') {
-        return this.hasCollaborator(cbOrUser, cb);
+    Repo.prototype.collaborators = function(cbParamOrUser, cb) {
+      var param;
+      if ((cb != null) && typeof cbParamOrUser !== 'function' && typeof cbParamOrUser !== 'object') {
+        return this.hasCollaborator(cbParamOrUser, cb);
       } else {
-        cb = cbOrUser;
-        return this.client.get("repos/" + this.name + "/collaborators", function(err, s, b, h) {
+        if (cb) {
+          param = cbParamOrUser;
+        } else {
+          cb = cbParamOrUser;
+          param = {};
+        }
+        return this.client.getOptions("/repos/" + this.name + "/collaborators", {
+          headers: {
+            Accept: 'application/vnd.github.ironman-preview+json'
+          }
+        }, param, function(err, s, b, h) {
           if (err) {
             return cb(err);
           }

--- a/src/octonode/repo.coffee
+++ b/src/octonode/repo.coffee
@@ -27,12 +27,16 @@ class Repo
 
   # Get the collaborators for a repository
   # '/repos/pksunkara/hub/collaborators
-  collaborators: (cbOrUser, cb) ->
-    if cb? and typeof cbOrUser isnt 'function'
-      @hasCollaborator cbOrUser, cb
+  collaborators: (cbParamOrUser, cb) ->
+    if cb? and typeof cbParamOrUser isnt 'function' and typeof cbParamOrUser isnt 'object'
+      @hasCollaborator cbParamOrUser, cb
     else
-      cb = cbOrUser
-      @client.get "repos/#{@name}/collaborators", (err, s, b, h) ->
+      if cb
+        param = cbParamOrUser
+      else
+        cb = cbParamOrUser
+        param = {}
+      @client.getOptions "/repos/#{@name}/collaborators", { headers: { Accept: 'application/vnd.github.ironman-preview+json'} }, param, (err, s, b, h)  ->
         return cb(err) if err
         if s isnt 200 then cb(new Error("Repo collaborators error")) else cb null, b, h
 


### PR DESCRIPTION
Hi,
This updates the repo `collaborators` method. Right now, the method is unable to accept paging parameters (per_page or page), so it only returns the first 100 collaborators.

Since the method has a switch experience for a provided username, passing the object with the filter parameters does not work.

This proposes a way to work around that: if the callback/user value is an object, then it is sent as the param to the get request.

This also updates the API to use the new GitHub organization API system; at this time, it just sends back an additional permission value for each user, whether they have admin/pull/push rights, but no other changes. Documented here: https://developer.github.com/v3/repos/collaborators/#list

Thoughts?

Thanks,
Jeff