### PR TITLE
Add team repo support for the new granularity of GitHub org mgmt

### DIFF
--- a/lib/octonode/client.js
+++ b/lib/octonode/client.js
@@ -290,14 +290,18 @@
       })(this));
     };
 
-    Client.prototype.put = function(path, content, callback) {
+    Client.prototype.put = function(path, content, options, callback) {
+      if (!callback && options) {
+        callback = options;
+        options = {
+          'Content-Type': 'application/json'
+        };
+      }
       return this.request(this.requestOptions({
         uri: this.buildUrl(path),
         method: 'PUT',
         body: JSON.stringify(content),
-        headers: {
-          'Content-Type': 'application/json'
-        }
+        headers: options
       }), (function(_this) {
         return function(err, res, body) {
           if (err) {

--- a/lib/octonode/org.js
+++ b/lib/octonode/org.js
@@ -201,8 +201,22 @@
       });
     };
 
-    Org.prototype.addTeamRepo = function(team, repo, cb) {
-      return this.client.put("/teams/" + team + "/repos/" + this.name + "/" + repo, null, function(err, s, b, h) {
+    Org.prototype.addTeamRepo = function(team, repo, cbOrOptions, cb) {
+      var options, param;
+      if ((cb == null) && cbOrOptions) {
+        cb = cbOrOptions;
+        param = {};
+        options = {
+          'Content-Type': 'application/json'
+        };
+      } else if (typeof cbOrOptions === 'object') {
+        param = cbOrOptions;
+        options = {
+          'Content-Type': 'application/json',
+          'Accept': 'application/vnd.github.ironman-preview+json'
+        };
+      }
+      return this.client.put("/teams/" + team + "/repos/" + this.name + "/" + repo, param, options, function(err, s, b, h) {
         if (err) {
           return cb(err);
         }

--- a/src/octonode/client.coffee
+++ b/src/octonode/client.coffee
@@ -200,13 +200,16 @@ class Client
       @errorHandle res, body, callback
 
   # Github api PUT request
-  put: (path, content, callback) ->
+  put: (path, content, options, callback) ->
+    if !callback and options
+      callback = options
+      options =
+        'Content-Type': 'application/json'
     @request @requestOptions(
       uri: @buildUrl path
       method: 'PUT'
       body: JSON.stringify content
-      headers:
-        'Content-Type': 'application/json'
+      headers: options
     ), (err, res, body) =>
       return callback(err) if err
       @errorHandle res, body, callback

--- a/src/octonode/org.coffee
+++ b/src/octonode/org.coffee
@@ -124,8 +124,18 @@ class Org
 
   # Add an organisation team repository
   # '/teams/37/repos/flatiron/hub' PUT
-  addTeamRepo: (team, repo, cb) ->
-    @client.put "/teams/#{team}/repos/#{@name}/#{repo}", null, (err, s, b, h) ->
+  addTeamRepo: (team, repo, cbOrOptions, cb) ->
+    if !cb? and cbOrOptions
+      cb = cbOrOptions
+      param = {}
+      options =
+        'Content-Type': 'application/json'
+    else if typeof cbOrOptions is 'object'
+      param = cbOrOptions
+      options =
+        'Content-Type': 'application/json'
+        'Accept': 'application/vnd.github.ironman-preview+json'
+    @client.put "/teams/#{team}/repos/#{@name}/#{repo}", param, options, (err, s, b, h) ->
       return cb(err)  if err
       if s isnt 204 then cb(new Error('Org addTeamRepo error')) else cb null, b, h
 


### PR DESCRIPTION
Hi,
With the new GItHub org management system, all teams now have per-repo granularity of permission - admin, pull, push; previously, the entire team had a specific level of permission.

This change is:
- Extending the standard `put` client code path to support an options parameter. This felt cleaner than duplicating the entire `put` method to then have a `putOptions` method, but this does mean it is not exactly the same as the get/getOptions split in the client.coffee file.
- Updates the org `addTeamRepo` method to take an optional parameter piece, where you could specify the permission per the API at https://developer.github.com/v3/orgs/teams/#add-team-repo

I've spoken with GitHub, and although everyone has been moved to the new GitHub org management system, their API system still requires the preview flags at this time.

Thanks,
Jeff