### PR TITLE
Updating package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,5 @@
   "engines": {
     "node": ">0.4.11"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.githubusercontent.com/pksunkara/octonode/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
Per modern "package.json" best practices (see also: https://docs.npmjs.com/files/package.json), the `licenses` property has been replaced by `license`. This helps remove the warning from `npm` when you install `octonode` about it missing `license`.