### PR TITLE
Allowing the user to patch their org membership.

### DIFF
--- a/lib/octonode/me.js
+++ b/lib/octonode/me.js
@@ -333,6 +333,23 @@
       }]));
     };
 
+    Me.prototype.updateMembership = function(org, state, cb) {
+      var info;
+      info = {
+        state: state
+      };
+      return this.client.patch("/user/memberships/orgs/" + org, info, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error('User org update error'));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Me.prototype.repo = function(nameOrRepo, cb) {
       if (typeof cb === 'function' && typeof nameOrRepo === 'object') {
         return this.createRepo(nameOrRepo, cb);

--- a/src/octonode/me.coffee
+++ b/src/octonode/me.coffee
@@ -197,6 +197,15 @@ class Me
       return cb(err) if err
       if s isnt 200 then cb(new Error('User orgs error')) else cb null, b, h
 
+  # Edit organization membership
+  # '/user/memberships/orgs/:org' PATCH
+  updateMembership: (org, state, cb) ->
+    info =
+      state: state
+    @client.patch "/user/memberships/orgs/#{org}", info, (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error('User org update error')) else cb null, b, h
+
   # Get repository instance for client
   repo: (nameOrRepo, cb) ->
     if typeof cb is 'function' and typeof nameOrRepo is 'object'


### PR DESCRIPTION
Hi,
Looking for feedback on the method name here. It's odd because the API feels generic, but has a very restrictive use, sending a single state parameter.

The API is: https://developer.github.com/v3/orgs/members/#edit-your-organization-membership
