### PR TITLE
Fix typo in README.md for org membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ ghorg.concealMembership('pksunkara', callback);
 #### Check a member's membership status (GET /orgs/flatiron/memberships/pksunkara)
 
 ```js
-ghorg.memberships('pksunkara', callback); //membership status object indicating state, role, etc.
+ghorg.membership('pksunkara', callback); //membership status object indicating state, role, etc.
 ```
 
 #### Create an organization team (POST /orgs/flatiron/teams)


### PR DESCRIPTION
Just a small typo fix. Took a while trying to debug what was wrong with my code and realized there was a typo in the documentation.