### PR TITLE
Treat any status other than 201 as error

### DIFF
--- a/lib/octonode/auth.js
+++ b/lib/octonode/auth.js
@@ -81,10 +81,10 @@
               err = _error;
               callback(new Error('Unable to parse body'));
             }
-            if (res.statusCode === 401) {
-              return callback(new Error(body.message));
-            } else {
+            if (res.statusCode === 201) {
               return callback(null, body.id, body.token);
+            } else {
+              return callback(new Error(body.message));
             }
           }
         });

--- a/src/octonode/auth.coffee
+++ b/src/octonode/auth.coffee
@@ -67,7 +67,7 @@ auth = module.exports =
             body = JSON.parse body
           catch err
             callback new Error('Unable to parse body')
-          if res.statusCode is 401 then callback(new Error(body.message)) else callback(null, body.id, body.token)
+          if res.statusCode is 201 then callback(null, body.id, body.token) else callback(new Error(body.message))
     else if @mode == @modes.web
       if scopes instanceof Array
         uri = 'https://github.com/login/oauth/authorize'


### PR DESCRIPTION
While working with this API I received a callback with neither a token nor an error -- stepping through `login()` this was caused by a non-401 error (specifically a 403 with this body: `"{"message":"This API can only be accessed with username and password Basic Auth","documentation_url":"https://developer.github.com/v3/oauth_authorizations/#oauth-authorizations-api"}"`)