### PR TITLE
Improve the CLI auth logic

### DIFF
--- a/lib/octonode/auth.js
+++ b/lib/octonode/auth.js
@@ -49,14 +49,21 @@
       }
     },
     login: function(scopes, callback) {
-      var options, uri;
+      var authorizationMethod, authorizationUrl, options, uri;
       if (this.mode === this.modes.cli) {
         if (!(scopes instanceof Array)) {
           scopes = [scopes];
         }
+        if (this.options.reuse && this.options.id) {
+          authorizationUrl = "https://api.github.com/authorizations/clients/" + this.options.id;
+          authorizationMethod = 'PUT';
+        } else {
+          authorizationUrl = "https://api.github.com/authorizations";
+          authorizationMethod = 'POST';
+        }
         options = {
-          url: url.parse("https://api.github.com/authorizations"),
-          method: 'POST',
+          url: url.parse(authorizationUrl),
+          method: authorizationMethod,
           body: JSON.stringify({
             scopes: scopes,
             client_id: this.options.id,
@@ -75,6 +82,7 @@
           options.headers['X-GitHub-OTP'] = this.options.otp;
         }
         return request(options, function(err, res, body) {
+          var ref;
           if (err != null) {
             return callback(err);
           } else {
@@ -84,7 +92,7 @@
               err = _error;
               callback(new Error('Unable to parse body'));
             }
-            if (res.statusCode === 201) {
+            if ((ref = res.statusCode) === 200 || ref === 201) {
               return callback(null, body.id, body.token);
             } else {
               return callback(new Error(body.message));

--- a/lib/octonode/auth.js
+++ b/lib/octonode/auth.js
@@ -51,17 +51,20 @@
     login: function(scopes, callback) {
       var options, uri;
       if (this.mode === this.modes.cli) {
-        if (scopes instanceof Array) {
-          scopes = JSON.stringify({
-            scopes: scopes
-          });
-        } else {
-          scopes = JSON.stringify(scopes);
+        if (!(scopes instanceof Array)) {
+          scopes = [scopes];
         }
         options = {
           url: url.parse("https://api.github.com/authorizations"),
           method: 'POST',
-          body: scopes,
+          body: JSON.stringify({
+            scopes: scopes,
+            client_id: this.options.id,
+            client_secret: this.options.secret,
+            fingerprint: this.options.fingerprint,
+            note: this.options.note,
+            note_url: this.options.note_url
+          }),
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'octonode/0.3 (https://github.com/pksunkara/octonode) terminal/0.0'

--- a/src/octonode/auth.coffee
+++ b/src/octonode/auth.coffee
@@ -43,14 +43,18 @@ auth = module.exports =
 
   login: (scopes, callback) ->
     if @mode == @modes.cli
-      if scopes instanceof Array
-        scopes = JSON.stringify scopes: scopes
-      else
-        scopes = JSON.stringify scopes
+      unless scopes instanceof Array
+        scopes = [ scopes ]
       options =
         url: url.parse "https://api.github.com/authorizations"
         method: 'POST'
-        body: scopes
+        body: JSON.stringify
+          scopes: scopes
+          client_id: @options.id
+          client_secret: @options.secret
+          fingerprint: @options.fingerprint
+          note: @options.note
+          note_url: @options.note_url
         headers:
           'Content-Type': 'application/json'
           'User-Agent': 'octonode/0.3 (https://github.com/pksunkara/octonode) terminal/0.0'

--- a/src/octonode/auth.coffee
+++ b/src/octonode/auth.coffee
@@ -45,9 +45,15 @@ auth = module.exports =
     if @mode == @modes.cli
       unless scopes instanceof Array
         scopes = [ scopes ]
+      if @options.reuse and @options.id
+        authorizationUrl = "https://api.github.com/authorizations/clients/#{@options.id}"
+        authorizationMethod = 'PUT'
+      else
+        authorizationUrl = "https://api.github.com/authorizations"
+        authorizationMethod = 'POST'
       options =
-        url: url.parse "https://api.github.com/authorizations"
-        method: 'POST'
+        url: url.parse authorizationUrl
+        method: authorizationMethod
         body: JSON.stringify
           scopes: scopes
           client_id: @options.id
@@ -71,7 +77,7 @@ auth = module.exports =
             body = JSON.parse body
           catch err
             callback new Error('Unable to parse body')
-          if res.statusCode is 201 then callback(null, body.id, body.token) else callback(new Error(body.message))
+          if res.statusCode in [200, 201] then callback(null, body.id, body.token) else callback(new Error(body.message))
     else if @mode == @modes.web
       if scopes instanceof Array
         uri = 'https://github.com/login/oauth/authorize'


### PR DESCRIPTION
These are changes I needed for creating a desktop application using this library:
1. Provide `client_id`, `client_secret`, `note`, `note_url`, and `fingerprint` in the authorization request
2. Allow reusing an existing authorization 

There is still one open issue here: github will return a hashed token and the last 8 characters when reusing a token, but these values are not provided to the callback, so the app cannot actually verify the token. I'll open a separate issue for that, as it might need incompatible changes to the API.
