### PR TITLE
updates depends based on  node security advisory report

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "test": "vows --spec $(find test -name '*.js')"
   },
   "dependencies": {
-    "request": "2.51.x",
-    "randomstring": "1.x.x",
-    "deep-extend": "0.x.x"
+    "deep-extend": "^0.4.1",
+    "randomstring": "^1.1.5",
+    "request": "^2.72.0"
   },
   "devDependencies": {
-    "nock": "0.57.x",
-    "vows": "0.8.x",
-    "coffee-script": "1.9.x"
+    "coffee-script": "^1.10.0",
+    "nock": "^8.0.0",
+    "vows": "^0.8.1"
   },
   "engines": {
     "node": ">0.4.11"


### PR DESCRIPTION
request had a bad dependency on hawk 

```
"vulnerabilities": [
      {
        "name": "hawk",
        "version": "1.1.1",
        "path": "octonode@0.7.5 => request@2.51.0 => hawk@1.1.1",
        "patchTo": ">=3.1.3 < 4.0.0 || >=4.1.1",
        "problem": "Regular Expression Denial of Service"
      }
    ]
```
<img width="465" alt="screen shot 2016-05-20 at 9 52 44 am" src="https://cloud.githubusercontent.com/assets/1854811/15440366/cc51570a-1e70-11e6-85d5-5226f189cc37.png">

Other modules were bumped for convenience 