### PR TITLE
bumps version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octonode",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": "Pavan Kumar Sunkara <pavan.sss1991@gmail.com> (http://pksunkara.github.com)",
   "description": "nodejs wrapper for github v3 api",
   "main": "./lib/octonode",


### PR DESCRIPTION
> to allow news dependencies to take effect

0.7.5 should be deprecated because it requires a package with a vulnerability.