### PR TITLE
Add two-factor auth cli documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ github.auth.config({
 });
 ```
 
+**With two-factor auth:**
+
+If two-factor authentication is enabled then you will need to supply the One Time Password (OTP) within the auth configuration. Ensure that the scopes argument is an object containing the required `note` property.
+
+```js
+
+var scopes = {
+  'add_scopes': ['user', 'repo', 'gist'],
+  'note': 'admin script'
+};
+
+github.auth.config({
+  username: 'pksunkara',
+  password: 'password',
+  otp: '46692'
+}).login(scopes, function (err, id, token) {
+  console.log(id, token);
+});
+```
+
 #### Revoke authentication to github in cli mode (desktop application)
 
 ```js

--- a/README.md
+++ b/README.md
@@ -113,21 +113,9 @@ __Many of the below use cases use parts of the above code__
 
 #### Authenticate to github in cli mode (desktop application)
 
-```js
-github.auth.config({
-  username: 'pksunkara',
-  password: 'password'
-}).login(['user', 'repo', 'gist'], function (err, id, token) {
-  console.log(id, token);
-});
-```
-
-**With two-factor auth:**
-
-If two-factor authentication is enabled then you will need to supply the One Time Password (OTP) within the auth configuration. Ensure that the scopes argument is an object containing the required `note` property.
+**Note:** Ensure that the scopes argument is an object containing the required `note` property. For two-factor authentication add the One Time Password `otp` key with its corresponding code to the configuration object.
 
 ```js
-
 var scopes = {
   'add_scopes': ['user', 'repo', 'gist'],
   'note': 'admin script'
@@ -135,8 +123,7 @@ var scopes = {
 
 github.auth.config({
   username: 'pksunkara',
-  password: 'password',
-  otp: '46692'
+  password: 'password'
 }).login(scopes, function (err, id, token) {
   console.log(id, token);
 });


### PR DESCRIPTION
Adds documentation to the README outlining how to use two-factor authentication whilst performing auth via the CLI mode.

This is in relation to me trying to figure out how this worked earlier with issue #250. Thanks @pksunkara for pointing me in the right direction.