### PR TITLE
Add support for getting combined status for a ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,12 @@ ghrepo.destroy();
 ghrepo.statuses('master', callback); //array of statuses
 ```
 
+#### List the combined status for a specific ref (GET /repos/pksunkara/hub/commits/master/status)
+
+```js
+ghrepo.combinedStatus('master', callback); //array of statuses
+```
+
 #### Create status (POST /repos/pksunkara/hub/statuses/SHA)
 
 ```js

--- a/src/octonode/repo.coffee
+++ b/src/octonode/repo.coffee
@@ -481,6 +481,13 @@ class Repo
       return cb(err) if err
       if s isnt 200 then cb(new Error("Repo statuses error")) else cb null, b, h
 
+  # Get the combined status for a specific ref
+  # '/repos/pksunkara/hub/commits/master/status' GET
+  combinedStatus: (ref, cb) ->
+    @client.get "/repos/#{@name}/commits/#{ref}/status", (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error("Repo statuses error")) else cb null, b, h
+
   # Create a status
   # '/repos/pksunkara/hub/statuses/18e129c213848c7f239b93fe5c67971a64f183ff' POST
   status: (sha, obj, cb) ->


### PR DESCRIPTION
Added support for getting the combined status for a specific ref (https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref).

@pksunkara 