### PR TITLE
Allow parameters in repo.updateContents

### DIFF
--- a/lib/octonode/repo.js
+++ b/lib/octonode/repo.js
@@ -545,17 +545,27 @@
       });
     };
 
-    Repo.prototype.updateContents = function(path, message, content, sha, cbOrBranch, cb) {
-      if ((cb == null) && cbOrBranch) {
-        cb = cbOrBranch;
-        cbOrBranch = 'master';
+    Repo.prototype.updateContents = function(path, message, content, sha, cbOrBranchOrOptions, cb) {
+      var params;
+      content = new Buffer(content).toString('base64');
+      if ((cb == null) && cbOrBranchOrOptions) {
+        cb = cbOrBranchOrOptions;
+        cbOrBranchOrOptions = 'master';
       }
-      return this.client.put("/repos/" + this.name + "/contents/" + path, {
-        branch: cbOrBranch,
-        message: message,
-        content: new Buffer(content).toString('base64'),
-        sha: sha
-      }, function(err, s, b, h) {
+      if (typeof cbOrBranchOrOptions === 'string') {
+        params = {
+          branch: cbOrBranchOrOptions,
+          message: message,
+          content: content,
+          sha: sha
+        };
+      } else if (typeof cbOrBranchOrOptions === 'object') {
+        params = cbOrBranchOrOptions;
+        params['message'] = message;
+        params['content'] = content;
+        params['sha'] = sha;
+      }
+      return this.client.put("/repos/" + this.name + "/contents/" + path, params, function(err, s, b, h) {
         if (err) {
           return cb(err);
         }

--- a/src/octonode/repo.coffee
+++ b/src/octonode/repo.coffee
@@ -327,11 +327,19 @@ class Repo extends Base
 
   # Update a file at a path in repository
   # '/repos/pksunkara/hub/contents/lib/index.js' PUT
-  updateContents: (path, message, content, sha, cbOrBranch, cb) ->
-    if !cb? and cbOrBranch
-      cb = cbOrBranch
-      cbOrBranch = 'master'
-    @client.put "/repos/#{@name}/contents/#{path}", {branch: cbOrBranch, message: message, content: new Buffer(content).toString('base64'), sha: sha}, (err, s, b, h) ->
+  updateContents: (path, message, content, sha, cbOrBranchOrOptions, cb) ->
+    content = new Buffer(content).toString('base64')
+    if !cb? and cbOrBranchOrOptions
+      cb = cbOrBranchOrOptions
+      cbOrBranchOrOptions = 'master'
+    if typeof cbOrBranchOrOptions is 'string'
+      params = {branch: cbOrBranchOrOptions, message: message, content: content, sha: sha}
+    else if typeof cbOrBranchOrOptions is 'object'
+      params = cbOrBranchOrOptions
+      params['message'] = message
+      params['content'] = content
+      params['sha'] = sha
+    @client.put "/repos/#{@name}/contents/#{path}", params, (err, s, b, h) ->
       return cb(err) if err
       if s isnt 200 then cb(new Error("Repo updateContents error")) else cb null, b, h
 


### PR DESCRIPTION
Allow the ability to pass optional parameters such as commiter and author to updateContents