### PR TITLE
[ISSUE #297] return headers in login callback for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ var scopes = {
 github.auth.config({
   username: 'pksunkara',
   password: 'password'
-}).login(scopes, function (err, id, token) {
+}).login(scopes, function (err, id, token, headers) {
   console.log(id, token);
 });
 ```

--- a/lib/octonode/auth.js
+++ b/lib/octonode/auth.js
@@ -76,7 +76,7 @@
         }
         return request(options, function(err, res, body) {
           if (err != null) {
-            return callback(err);
+            return callback(err, null, null, res.headers);
           } else {
             try {
               body = JSON.parse(body);
@@ -85,9 +85,9 @@
               callback(new Error('Unable to parse body'));
             }
             if (res.statusCode === 201) {
-              return callback(null, body.id, body.token);
+              return callback(null, body.id, body.token, res.headers);
             } else {
-              return callback(new Error(body.message));
+              return callback(new Error(body.message), null, null, res.headers);
             }
           }
         });

--- a/src/octonode/auth.coffee
+++ b/src/octonode/auth.coffee
@@ -63,13 +63,13 @@ auth = module.exports =
 
       request options, (err, res, body) ->
         if err?
-          callback err
+          callback(err, null, null, res.headers)
         else
           try
             body = JSON.parse body
           catch err
             callback new Error('Unable to parse body')
-          if res.statusCode is 201 then callback(null, body.id, body.token) else callback(new Error(body.message))
+          if res.statusCode is 201 then callback(null, body.id, body.token, res.headers) else callback(new Error(body.message), null, null, res.headers)
     else if @mode == @modes.web
       if scopes instanceof Array
         uri = "#{@options.webUrl}/login/oauth/authorize"


### PR DESCRIPTION
resolves #297

Let me know if you want me to do something similar in the `web` login flow

basically, changed the login function to this:
```js
var scopes = {
  'add_scopes': ['user', 'repo', 'gist'],
  'note': 'admin script'
};

github.auth.config({
  username: 'pksunkara',
  password: 'password'
}).login(scopes, function (err, id, token, headers) {
  console.log(id, token);
});
```