### PR TITLE
fix add_scopes to scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ More info about conditional requests can be founded [here](https://developer.git
 
 ```js
 var scopes = {
-  'add_scopes': ['user', 'repo', 'gist'],
+  'scopes': ['user', 'repo', 'gist'],
   'note': 'admin script'
 };
 


### PR DESCRIPTION
`add_scopes` doesn't work. changing the readme to reflect the working attribute `scopes`