### PR TITLE
Support looking up a release by tag name

### DIFF
--- a/lib/octonode/repo.js
+++ b/lib/octonode/repo.js
@@ -226,6 +226,19 @@
       }
     };
 
+    Repo.prototype.releaseByTag = function(tag, cb) {
+      return this.client.get("/repos/" + this.name + "/releases/tags/" + tag, function(err, s, b, h) {
+        if (err) {
+          return cb(err);
+        }
+        if (s !== 200) {
+          return cb(new Error("Repo releaseByTag error"));
+        } else {
+          return cb(null, b, h);
+        }
+      });
+    };
+
     Repo.prototype.createRelease = function(release, cb) {
       return this.client.post("/repos/" + this.name + "/releases", release, function(err, s, b, h) {
         if (err) {

--- a/src/octonode/repo.coffee
+++ b/src/octonode/repo.coffee
@@ -133,6 +133,12 @@ class Repo extends Base
     else
       @client.release @name, numberOrRelease
 
+  # Get the release associated to a tag name
+  releaseByTag: (tag, cb) ->
+    @client.get "/repos/#{@name}/releases/tags/#{tag}", (err, s, b, h) ->
+      return cb(err) if err
+      if s isnt 200 then cb(new Error("Repo releaseByTag error")) else cb null, b, h
+
   # Create a relase for a repo
   # '/repo/pksunkara/releases' POST
   createRelease: (release, cb) ->


### PR DESCRIPTION
This adds support for [this endpoint](https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name)